### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     environment: tests
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']


### PR DESCRIPTION
Potential fix for [https://github.com/matfax/docker-compose-mcp/security/code-scanning/11](https://github.com/matfax/docker-compose-mcp/security/code-scanning/11)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/build.yml`. This block should specify the minimal required permissions, which in this case is likely just `contents: read`, as the job only needs to read the repository contents to run tests. The block should be added at the same level as `runs-on`, `environment`, and `strategy` within the `test` job definition. No other changes are required, and this will not affect the existing functionality of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
